### PR TITLE
並び替えの実装 #31

### DIFF
--- a/kancolle-timer-frontend/package.json
+++ b/kancolle-timer-frontend/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.40.0",
     "react-scripts": "5.0.1",
+    "react-smooth-dnd": "^0.11.1",
     "typescript": "^4.9.4",
     "web-vitals": "^2.1.4"
   },

--- a/kancolle-timer-frontend/package.json
+++ b/kancolle-timer-frontend/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^7.0.2",
+    "@dnd-kit/utilities": "^3.2.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.11.0",
@@ -19,7 +22,6 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.40.0",
     "react-scripts": "5.0.1",
-    "react-smooth-dnd": "^0.11.1",
     "typescript": "^4.9.4",
     "web-vitals": "^2.1.4"
   },

--- a/kancolle-timer-frontend/src/components/Timer/ShowTimer.tsx
+++ b/kancolle-timer-frontend/src/components/Timer/ShowTimer.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, IconButton } from '@mui/material';
+import { Box, Button, IconButton, ListItem, Paper } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { Timer } from '../../API';
 import useShowTimer from './useShowTimer';
@@ -94,27 +94,31 @@ const ShowTimer = (props: Props) => {
 
   return (
     <>
-      <Box sx={{ display: 'flex', m: 1 }}>
-        <Box sx={{ flex: 1 }}>{timerMsg}</Box>
-        <Box sx={{ flex: 1 }}>{formatTime(timer.time)}</Box>
-        <Box sx={{ flex: 1 }}>{formatEndTime(timer.endTime)}</Box>
-        {createButton()}
-        <IconButton
-          sx={{ ml: 1 }}
-          onClick={() => {
-            setOpen(true);
-          }}
-        >
-          <DeleteIcon />
-        </IconButton>
-        <GenericDialog
-          msg={deleteMsg}
-          isOpen={open}
-          doOk={deleteTimer}
-          doCancel={() => setOpen(false)}
-          irreversibleFlag
-        />
-      </Box>
+      <ListItem sx={{ p: 0.5 }}>
+        <Paper elevation={3} sx={{ width: '100%' }}>
+          <Box sx={{ display: 'flex', m: 1 }}>
+            <Box sx={{ flex: 1 }}>{timerMsg}</Box>
+            <Box sx={{ flex: 1 }}>{formatTime(timer.time)}</Box>
+            <Box sx={{ flex: 1 }}>{formatEndTime(timer.endTime)}</Box>
+            {createButton()}
+            <IconButton
+              sx={{ ml: 1 }}
+              onClick={() => {
+                setOpen(true);
+              }}
+            >
+              <DeleteIcon />
+            </IconButton>
+            <GenericDialog
+              msg={deleteMsg}
+              isOpen={open}
+              doOk={deleteTimer}
+              doCancel={() => setOpen(false)}
+              irreversibleFlag
+            />
+          </Box>
+        </Paper>
+      </ListItem>
     </>
   );
 };

--- a/kancolle-timer-frontend/src/components/Timer/ShowTimer.tsx
+++ b/kancolle-timer-frontend/src/components/Timer/ShowTimer.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { Box, Button, IconButton, ListItem, Paper } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
 import { Timer } from '../../API';
 import useShowTimer from './useShowTimer';
 import GenericDialog from '../GenericDialog';
@@ -14,6 +17,7 @@ const ShowTimer = (props: Props) => {
   const { timer, organizeAfterDelete } = props;
   const { callStartTimer, callStopTimer, callDeleteTimer } = useShowTimer();
   const [open, setOpen] = useState<boolean>(false);
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: timer.id });
 
   const formatTime = (time: string | null | undefined) => {
     if (!time) {
@@ -92,32 +96,42 @@ const ShowTimer = (props: Props) => {
   const deleteMsg = (timer.name ? timer.name : formatTime(timer.time) + 'のタイマー') + ' を削除しますか？';
   const timerMsg = formatTimeName((timer.isTemped ? 'T: ' : '') + (timer.name ? timer.name : formatTime(timer.time)));
 
+  const style = {
+    width: '100%',
+    cursor: 'move',
+    listStyle: 'none',
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   return (
     <>
-      <ListItem sx={{ p: 0.5 }}>
-        <Paper elevation={3} sx={{ width: '100%' }}>
-          <Box sx={{ display: 'flex', m: 1 }}>
-            <Box sx={{ flex: 1 }}>{timerMsg}</Box>
-            <Box sx={{ flex: 1 }}>{formatTime(timer.time)}</Box>
-            <Box sx={{ flex: 1 }}>{formatEndTime(timer.endTime)}</Box>
-            {createButton()}
-            <IconButton
-              sx={{ ml: 1 }}
-              onClick={() => {
-                setOpen(true);
-              }}
-            >
-              <DeleteIcon />
-            </IconButton>
-            <GenericDialog
-              msg={deleteMsg}
-              isOpen={open}
-              doOk={deleteTimer}
-              doCancel={() => setOpen(false)}
-              irreversibleFlag
-            />
-          </Box>
-        </Paper>
+      <ListItem>
+        <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+          <Paper elevation={3} sx={{ width: '100%', p: 0.5 }}>
+            <Box sx={{ display: 'flex', m: 1 }}>
+              <Box sx={{ flex: 1 }}>{timerMsg}</Box>
+              <Box sx={{ flex: 1 }}>{formatTime(timer.time)}</Box>
+              <Box sx={{ flex: 1 }}>{formatEndTime(timer.endTime)}</Box>
+              {createButton()}
+              <IconButton
+                sx={{ ml: 1 }}
+                onClick={() => {
+                  setOpen(true);
+                }}
+              >
+                <DeleteIcon />
+              </IconButton>
+              <GenericDialog
+                msg={deleteMsg}
+                isOpen={open}
+                doOk={deleteTimer}
+                doCancel={() => setOpen(false)}
+                irreversibleFlag
+              />
+            </Box>
+          </Paper>
+        </div>
       </ListItem>
     </>
   );

--- a/kancolle-timer-frontend/src/components/Timer/index.tsx
+++ b/kancolle-timer-frontend/src/components/Timer/index.tsx
@@ -1,20 +1,56 @@
 import { Box, Container, List } from '@mui/material';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
+
 import EditTimer from './EditTimer';
 import ShowTimer from './ShowTimer';
 import useTimerIndex from './useIndexTimer';
 
 const Timer = () => {
-  const { timersArray, organizeAfterDelete } = useTimerIndex();
+  const { timersArray, organizeAfterDelete, changeTimerOrder } = useTimerIndex();
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over) {
+      return;
+    }
+
+    if (active.id !== over.id) {
+      const oldIndex = timersArray.findIndex((v) => v.id === active.id);
+      const newIndex = timersArray.findIndex((v) => v.id === over.id);
+      changeTimerOrder(oldIndex, newIndex);
+    }
+  };
+
   return (
     <>
       <Container maxWidth='sm'>
         <Box sx={{ minWidth: '450px' }}>
-          <List>
-            {timersArray &&
-              timersArray.map((t) => {
-                return <ShowTimer key={t.id} timer={t} organizeAfterDelete={organizeAfterDelete} />;
-              })}
-          </List>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={timersArray} strategy={verticalListSortingStrategy}>
+              <List>
+                {timersArray &&
+                  timersArray.map((t) => {
+                    return <ShowTimer key={t.id} timer={t} organizeAfterDelete={organizeAfterDelete} />;
+                  })}
+              </List>
+            </SortableContext>
+          </DndContext>
           <Box sx={{ m: 2 }}>
             <EditTimer timerListSize={timersArray.length} />
           </Box>

--- a/kancolle-timer-frontend/src/components/Timer/index.tsx
+++ b/kancolle-timer-frontend/src/components/Timer/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Container } from '@mui/material';
+import { Box, Container, List } from '@mui/material';
 import EditTimer from './EditTimer';
 import ShowTimer from './ShowTimer';
 import useTimerIndex from './useIndexTimer';
@@ -9,10 +9,12 @@ const Timer = () => {
     <>
       <Container maxWidth='sm'>
         <Box sx={{ minWidth: '450px' }}>
-          {timersArray &&
-            timersArray.map((t) => {
-              return <ShowTimer key={t.id} timer={t} organizeAfterDelete={organizeAfterDelete} />;
-            })}
+          <List>
+            {timersArray &&
+              timersArray.map((t) => {
+                return <ShowTimer key={t.id} timer={t} organizeAfterDelete={organizeAfterDelete} />;
+              })}
+          </List>
           <Box sx={{ m: 2 }}>
             <EditTimer timerListSize={timersArray.length} />
           </Box>

--- a/kancolle-timer-frontend/yarn.lock
+++ b/kancolle-timer-frontend/yarn.lock
@@ -9861,7 +9861,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@>=15.6.0, prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10100,6 +10100,14 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-smooth-dnd@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/react-smooth-dnd/-/react-smooth-dnd-0.11.1.tgz#8d976137854c95f8fc09aa1ebc3069f69ceed6fa"
+  integrity sha512-+lVWQwPlK980VbFLtMSKfAJBt5ep37H/rVm3OnFiTpMFAghB9YQmrj3MnoIZ8tF+/niM/FFLpnSo8IgnbEY4Kg==
+  dependencies:
+    prop-types ">=15.6.0"
+    smooth-dnd "0.12.1"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -10587,6 +10595,11 @@ slash@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
+smooth-dnd@0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/smooth-dnd/-/smooth-dnd-0.12.1.tgz#cdb44c972355659e32770368b29b6a80e0ed96f1"
+  integrity sha512-Dndj/MOG7VP83mvzfGCLGzV2HuK1lWachMtWl/Iuk6zV7noDycIBnflwaPuDzoaapEl3Pc4+ybJArkkx9sxPZg==
 
 sockjs@^0.3.24:
   version "0.3.24"

--- a/kancolle-timer-frontend/yarn.lock
+++ b/kancolle-timer-frontend/yarn.lock
@@ -3329,6 +3329,37 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz#1bfafe4b7ed0f3e4105837e056e0a89b108ebe36"
   integrity sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==
 
+"@dnd-kit/accessibility@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz#3ccbefdfca595b0a23a5dc57d3de96bc6935641c"
+  integrity sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.0.8":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.0.8.tgz#040ae13fea9787ee078e5f0361f3b49b07f3f005"
+  integrity sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.0.0"
+    "@dnd-kit/utilities" "^3.2.1"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-7.0.2.tgz#791d550872457f3f3c843e00d159b640f982011c"
+  integrity sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.0", "@dnd-kit/utilities@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.1.tgz#53f9e2016fd2506ec49e404c289392cfff30332a"
+  integrity sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/babel-plugin@^11.10.5":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
@@ -9861,7 +9892,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@>=15.6.0, prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10100,14 +10131,6 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
-
-react-smooth-dnd@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/react-smooth-dnd/-/react-smooth-dnd-0.11.1.tgz#8d976137854c95f8fc09aa1ebc3069f69ceed6fa"
-  integrity sha512-+lVWQwPlK980VbFLtMSKfAJBt5ep37H/rVm3OnFiTpMFAghB9YQmrj3MnoIZ8tF+/niM/FFLpnSo8IgnbEY4Kg==
-  dependencies:
-    prop-types ">=15.6.0"
-    smooth-dnd "0.12.1"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -10595,11 +10618,6 @@ slash@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
-
-smooth-dnd@0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/smooth-dnd/-/smooth-dnd-0.12.1.tgz#cdb44c972355659e32770368b29b6a80e0ed96f1"
-  integrity sha512-Dndj/MOG7VP83mvzfGCLGzV2HuK1lWachMtWl/Iuk6zV7noDycIBnflwaPuDzoaapEl3Pc4+ybJArkkx9sxPZg==
 
 sockjs@^0.3.24:
   version "0.3.24"


### PR DESCRIPTION
close #31 
- タイマー表示についてPaperを使用した
- dnd-kitを導入し、フロントエンド部分の並び替え表示を行った
- order更新はクライアント側で先行して行い、その後サーバー側へ更新内容を送信する
  - サブスクライブで更新内容が通知されるが同じ内容になるので問題ない
  - サブスクライブを待って更新すると、クライアント側での表示が意図したものにならない場合があるため、クライアント側で先行して更新する