### PR TITLE
タイトル指定がない際のslack通知を修正 #35

### DIFF
--- a/kancolle-timer-backend/src/script.py
+++ b/kancolle-timer-backend/src/script.py
@@ -140,7 +140,10 @@ def main():
             if t["isTemped"]:
                 t["order"] = -1
             t["endTime"] = None
-            messages.append(f"{t['name']}のタイマーが終了しました。")
+            name = t["name"]
+            if name is None or name == "":
+                name = t["time"]
+            messages.append(f"{name}のタイマーが終了しました。")
 
     new_index = -1
     for i in range(len(timers)):


### PR DESCRIPTION
close #35 
- スクリプトを修正。nameが存在しない場合に時間を表示
  - Slackでの表示名がNoneや空文字列になる際の対策
  - フォーマットはhh:mmとなる