### PR TITLE
AppSyncへのリクエストについてアラートの設定 #45

### DIFF
--- a/kancolle-timer-backend/Terraform/alarm.tf
+++ b/kancolle-timer-backend/Terraform/alarm.tf
@@ -1,3 +1,7 @@
+data "aws_sns_topic" "this" {
+  name = var.sns_topic_name
+}
+
 resource "aws_cloudwatch_metric_alarm" "this" {
   alarm_name          = "${local.identifier}-appsync-alarm"
   comparison_operator = "GreaterThanThreshold"
@@ -8,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "this" {
   statistic           = "SampleCount"
   threshold           = 100
   alarm_actions = [
-    "damy",
+    data.aws_sns_topic.this.arn,
   ]
   alarm_description   = <<-EOT
         アクセスカウントのアラート
@@ -17,6 +21,6 @@ resource "aws_cloudwatch_metric_alarm" "this" {
     EOT
   datapoints_to_alarm = 1
   dimensions = {
-    "GraphQLAPIId" = "damy"
+    "GraphQLAPIId" = var.graphql_api_id
   }
 }

--- a/kancolle-timer-backend/Terraform/alarm.tf
+++ b/kancolle-timer-backend/Terraform/alarm.tf
@@ -1,0 +1,22 @@
+resource "aws_cloudwatch_metric_alarm" "this" {
+  alarm_name          = "${local.identifier}-appsync-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "4XXError"
+  namespace           = "AWS/AppSync"
+  period              = 60
+  statistic           = "SampleCount"
+  threshold           = 100
+  alarm_actions = [
+    "damy",
+  ]
+  alarm_description   = <<-EOT
+        アクセスカウントのアラート
+        1分間に100アクセスあった場合に発行
+        異常アクセスを検知
+    EOT
+  datapoints_to_alarm = 1
+  dimensions = {
+    "GraphQLAPIId" = "damy"
+  }
+}

--- a/kancolle-timer-backend/Terraform/variables.tf
+++ b/kancolle-timer-backend/Terraform/variables.tf
@@ -23,4 +23,11 @@ variable "sqs_url" {
 variable "sqs_name" {
   type = string
 }
+variable "sns_topic_name" {
+  type = string
+}
+variable "graphql_api_id" {
+  type      = string
+  sensitive = true
+}
 


### PR DESCRIPTION
close #45 
- AppSyncにログを取るように追加設定
  - Amplifyとの兼ね合いで、この設定はコンソールから手作業で行った
- それを基にアラートを作成
  - 1分間に100回のリクエスト
  - 最終的にメールで通知する
  - snsトピックはトピック名、appsyncはidを引数に指定