### PR TITLE
通信切断への対応 #46

### DIFF
--- a/kancolle-timer-frontend/src/pages/Top.tsx
+++ b/kancolle-timer-frontend/src/pages/Top.tsx
@@ -1,9 +1,16 @@
+import { useState } from 'react';
+import { ToggleButton } from '@mui/material';
 import Timer from '../components/Timer';
 
 const Top = () => {
+  const [flg, setFlg] = useState(false);
   return (
     <>
-      <Timer />
+      <ToggleButton value='check' selected={flg} onChange={() => setFlg(!flg)}>
+        {flg ? 'ON' : 'OFF'}
+      </ToggleButton>
+      <br />
+      {!flg && <Timer />}
     </>
   );
 };

--- a/kancolle-timer-frontend/src/pages/Top.tsx
+++ b/kancolle-timer-frontend/src/pages/Top.tsx
@@ -1,16 +1,9 @@
-import { useState } from 'react';
-import { ToggleButton } from '@mui/material';
 import Timer from '../components/Timer';
 
 const Top = () => {
-  const [flg, setFlg] = useState(false);
   return (
     <>
-      <ToggleButton value='check' selected={flg} onChange={() => setFlg(!flg)}>
-        {flg ? 'ON' : 'OFF'}
-      </ToggleButton>
-      <br />
-      {!flg && <Timer />}
+      <Timer />
     </>
   );
 };


### PR DESCRIPTION
close #46 
- 通信状態を監視する処理を追加
  - 通信状態が`connected`になった際に一覧取得を行う
- ネットワークの状態によっては、頻繁な状態変化が発生する可能性があるため、一覧取得処理を30秒に1回に制限
  - 前回リクエストした時刻はレンダリングとは関係無いためrefで管理している